### PR TITLE
Correct Greek exposure signage and scaling

### DIFF
--- a/modules/calc.py
+++ b/modules/calc.py
@@ -222,23 +222,24 @@ def calc_exposures(
 
     # ---=== CALCULATE EXPOSURES ===---
     option_data["call_dex"] = (
-        option_data["call_delta"].to_numpy() * call_open_interest * spot_price
+        option_data["call_delta"].to_numpy() * call_open_interest * spot_price * 0.01
     )
     option_data["put_dex"] = (
-        option_data["put_delta"].to_numpy() * put_open_interest * spot_price
+        option_data["put_delta"].to_numpy() * put_open_interest * spot_price * 0.01
     )
     option_data["call_gex"] = (
         option_data["call_gamma"].to_numpy()
         * call_open_interest
         * spot_price
         * spot_price
+        * 0.01
     )
     option_data["put_gex"] = (
         option_data["put_gamma"].to_numpy()
         * put_open_interest
         * spot_price
         * spot_price
-        * -1
+        * 0.01
     )
     logger.debug(f"np_spot_price: {np_spot_price}, opt_put_ivs: {opt_put_ivs}, time_till_exp: {time_till_exp}, dividend_yield: {dividend_yield}, put_open_interest: {put_open_interest}, put_dp: {put_dp}, put_pdf_dp: {put_pdf_dp}")
     option_data["call_vex"] = np.where(
@@ -307,10 +308,10 @@ def calc_exposures(
         option_data["call_gex"].to_numpy() + option_data["put_gex"].to_numpy()
     ) / 10**9
     option_data["total_vanna"] = (
-        option_data["call_vex"].to_numpy() - option_data["put_vex"].to_numpy()
+        option_data["call_vex"].to_numpy() + option_data["put_vex"].to_numpy()
     ) / 10**9
     option_data["total_charm"] = (
-        option_data["call_cex"].to_numpy() - option_data["put_cex"].to_numpy()
+        option_data["call_cex"].to_numpy() + option_data["put_cex"].to_numpy()
     ) / 10**9
 
     # group all options by strike / expiration then average their IVs
@@ -480,11 +481,11 @@ def calc_exposures(
     # delta exposure
     totaldelta["all"] = (call_delta_ex.sum(axis=1) + put_delta_ex.sum(axis=1)) / 10**9
     # gamma exposure
-    totalgamma["all"] = (call_gamma_ex.sum(axis=1) - put_gamma_ex.sum(axis=1)) / 10**9
+    totalgamma["all"] = (call_gamma_ex.sum(axis=1) + put_gamma_ex.sum(axis=1)) / 10**9
     # vanna exposure
-    totalvanna["all"] = (call_vanna_ex.sum(axis=1) - put_vanna_ex.sum(axis=1)) / 10**9
+    totalvanna["all"] = (call_vanna_ex.sum(axis=1) + put_vanna_ex.sum(axis=1)) / 10**9
     # charm exposure
-    totalcharm["all"] = (call_charm_ex.sum(axis=1) - put_charm_ex.sum(axis=1)) / 10**9
+    totalcharm["all"] = (call_charm_ex.sum(axis=1) + put_charm_ex.sum(axis=1)) / 10**9
 
     # Find Delta Flip Point
     zero_cross_idx = np.where(np.diff(np.sign(totaldelta["all"])))[0]

--- a/modules/stats.py
+++ b/modules/stats.py
@@ -116,7 +116,7 @@ def calc_delta_ex(S, T, q, opt_type, OI, cdf_dp):
     else:
         delta = -np.exp(-q * T) * (1 - cdf_dp)
     # change in option price per one percent move in underlying
-    return delta * OI * S
+    return delta * OI * S * 0.01
 
 
 @njit(
@@ -138,7 +138,7 @@ def calc_gamma_ex(S, vol, T, q, OI, pdf_dp):
     """
     gamma = np.exp(-q * T) * pdf_dp / (S * vol * np.sqrt(T))
     # change in delta per one percent move in underlying
-    return gamma * OI * S * S  # Gamma is same formula for calls and puts
+    return gamma * OI * S * S * 0.01  # Gamma is same formula for calls and puts
 
 
 @njit(
@@ -169,7 +169,7 @@ def calc_vanna_ex(S, vol, T, q, OI, dp, pdf_dp):
     vanna = -np.exp(-q * T) * pdf_dp * (dm / vol)
     # change in delta per one percent move in IV
     # or change in vega per one percent move in underlying
-    return vanna * OI * S * vol  # Vanna is same formula for calls and puts
+    return vanna * OI * S * 0.01  # Vanna is same formula for calls and puts
 
 
 @njit(
@@ -212,4 +212,4 @@ def calc_charm_ex(S, vol, T, r, q, opt_type, OI, dp, cdf_dp, pdf_dp):
             2 * (r - q) * T - dm * vol * np.sqrt(T)
         ) / (2 * T * vol * np.sqrt(T))
     # change in delta per day until expiration
-    return charm * OI * S * T
+    return charm * OI * S * (1.0 / 365.0)

--- a/tests/test_greeks_logic.py
+++ b/tests/test_greeks_logic.py
@@ -1,0 +1,104 @@
+import pytest
+import numpy as np
+import pandas as pd
+from datetime import datetime
+from zoneinfo import ZoneInfo
+from modules.calc import calc_exposures
+
+def test_greeks_additive_sign_and_scaling():
+    # Setup dummy data for a straddle at 100 strike
+    # Both call and put have same OI, same IV, same strike.
+    tz = 'UTC'
+    today_ddt = datetime(2024, 1, 1, 10, 0, 0, tzinfo=ZoneInfo(tz))
+
+    # 0.1 year to expiry
+    exp_date = today_ddt + pd.Timedelta(days=36.5)
+
+    data = {
+        'strike_price': [100.0],
+        'expiration_date': [exp_date],
+        'time_till_exp': [0.1],
+        'call_iv': [0.2],
+        'put_iv': [0.2],
+        'call_open_int': [1000.0],
+        'put_open_int': [1000.0],
+        'call_delta': [0.5],
+        'put_delta': [-0.5],
+        'call_gamma': [0.05],
+        'put_gamma': [0.05]
+    }
+    df = pd.DataFrame(data)
+
+    spot_price = 100.0
+
+    # Call calc_exposures
+    # We need to mock get_risk_free_rate or ensure it returns a value
+    from unittest.mock import patch
+    with patch('modules.calc.get_risk_free_rate', return_value=0.0):
+        (
+            option_data, _, _, _, _, _, _,
+            totaldelta, totalgamma, totalvanna, totalcharm,
+            _, _, _, _
+        ) = calc_exposures(df, 'TEST', 'all', spot_price, today_ddt, 'dummy_date')
+
+    # Delta: Call (0.5 * 1000 * 100 * 0.01) + Put (-0.5 * 1000 * 100 * 0.01) = 500 - 500 = 0
+    # Scaled by 10^9 in option_data
+    assert option_data['total_delta'].sum() == pytest.approx(0.0)
+
+    # Gamma: Call (0.05 * 1000 * 100 * 100 * 0.01) + Put (0.05 * 1000 * 100 * 100 * 0.01)
+    # = 5000 + 5000 = 10000
+    # Scaled by 10^9
+    expected_gamma = (10000.0) / 1e9
+    assert option_data['total_gamma'].sum() == pytest.approx(expected_gamma)
+
+    # Total Greeks in dataframe should also be additive
+    # Check total_vanna and total_charm
+    # Since Call and Put have same params, their Vanna/Charm (from BS) should be same
+    # total_vanna = call_vex + put_vex (both should be positive or negative but same sign)
+    assert option_data['total_vanna'].iloc[0] == pytest.approx(
+        (option_data['call_vex'].iloc[0] + option_data['put_vex'].iloc[0]) / 1e9
+    )
+    assert option_data['total_charm'].iloc[0] == pytest.approx(
+        (option_data['call_cex'].iloc[0] + option_data['put_cex'].iloc[0]) / 1e9
+    )
+
+def test_scaling_values():
+    # Verify exact values if possible
+    # For S=100, K=100, vol=0.2, T=0.1, r=0, q=0
+    # d1 = (0 + (0.5*0.04)*0.1) / (0.2 * sqrt(0.1)) = 0.002 / 0.063245 = 0.031622
+    # pdf(d1) = 1/sqrt(2pi) * exp(-0.5 * d1^2) = 0.398942 * 0.9995 = 0.39874
+    # Gamma = pdf(d1) / (S * vol * sqrt(T)) = 0.39874 / (100 * 0.2 * 0.31622) = 0.39874 / 6.3245 = 0.063047
+
+    # Exposure = Gamma * OI * S^2 * 0.01
+    # For OI=1000: 0.063047 * 1000 * 10000 * 0.01 = 6304.7
+
+    tz = 'UTC'
+    today_ddt = datetime(2024, 1, 1, 10, 0, 0, tzinfo=ZoneInfo(tz))
+    exp_date = today_ddt + pd.Timedelta(days=36.5)
+
+    data = {
+        'strike_price': [100.0],
+        'expiration_date': [exp_date],
+        'time_till_exp': [0.1],
+        'call_iv': [0.2],
+        'put_iv': [0.2],
+        'call_open_int': [1000.0],
+        'put_open_int': [0.0], # Only Call
+        'call_delta': [0.5126], # Approximate
+        'put_delta': [-0.4874],
+        'call_gamma': [0.063047],
+        'put_gamma': [0.063047]
+    }
+    df = pd.DataFrame(data)
+
+    spot_price = 100.0
+    from unittest.mock import patch
+    with patch('modules.calc.get_risk_free_rate', return_value=0.0):
+        (
+            option_data, _, _, _, _, _, _,
+            _, totalgamma, _, _,
+            _, _, _, _
+        ) = calc_exposures(df, 'TEST', 'all', spot_price, today_ddt, 'dummy_date')
+
+    expected_gex_notional = 6304.7
+    assert option_data['call_gex'].iloc[0] == pytest.approx(expected_gex_notional, rel=1e-3)


### PR DESCRIPTION
This change fixes the calculation of Greek exposures (Delta, Gamma, Vanna, Charm) to ensure correct market signage and consistent scaling. Specifically, Gamma, Vanna, and Charm total exposures are now additive, and scaling has been adjusted to "per 1% move" for price/IV and "per day" for time decay. A new test file `tests/test_greeks_logic.py` verifies these changes.

---
*PR created automatically by Jules for task [6162328627790868745](https://jules.google.com/task/6162328627790868745) started by @fxarb*