### PR TITLE
Remove 15-minute delay logic

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # G|Flows
 
-G|Flows, or Greek Flows, provides 15-minute updates for the SPX, NDX, and RUT indexes every Monday-Friday from 9:00am-4:30pm ET.
+G|Flows, or Greek Flows, provides updates for the SPX, NDX, and RUT indexes every Monday-Friday from 9:00am-4:30pm ET.
 
 ## Features
 

--- a/modules/calc.py
+++ b/modules/calc.py
@@ -568,8 +568,8 @@ def get_options_data_json(ticker, expir, tz):
         }
     ).get_date_data(str(data["timestamp"][0]))
     # Handle date formats
-    today_ddt = today_date.date_obj - timedelta(minutes=15)
-    today_ddt_string = today_ddt.strftime("%Y %b %d, %I:%M %p %Z") + " (15min delay)"
+    today_ddt = today_date.date_obj
+    today_ddt_string = today_ddt.strftime("%Y %b %d, %I:%M %p %Z")
 
     option_data = format_data(
         data["data.options"][0],
@@ -718,8 +718,8 @@ def get_options_data_csv(ticker, expir, tz):
             "RETURN_AS_TIMEZONE_AWARE": True,
         }
     ).get_date_data(today_date)
-    today_ddt = today_date.date_obj - timedelta(minutes=15)
-    today_ddt_string = today_ddt.strftime("%Y %b %d, %I:%M %p %Z") + " (15min delay)"
+    today_ddt = today_date.date_obj
+    today_ddt_string = today_ddt.strftime("%Y %b %d, %I:%M %p %Z")
 
     option_data["expiration_date"] = pd.to_datetime(
         option_data["expiration_date"], format="%a %b %d %Y"

--- a/modules/layout.py
+++ b/modules/layout.py
@@ -67,7 +67,7 @@ def serve_layout():
                                 can affect option prices. ",
                                 html.Br(),
                                 html.Span(
-                                    "Monday-Friday: 15-minute updates from 9:00am-4:30pm ET (CBOE delayed data)",
+                                    "Monday-Friday: updates from 9:00am-4:30pm ET",
                                     className="fst-italic",
                                 ),
                             ]

--- a/modules/ticker_dwn.py
+++ b/modules/ticker_dwn.py
@@ -20,7 +20,7 @@ def fulfill_req(ticker, is_json, session):
     """
     logger.debug(f"Fulfilling request for ticker: {ticker}, is_json: {is_json}")
     # The URL of the API to download the data from.
-    api_url = environ.get("API_URL", 'https://cdn.cboe.com/api/global/delayed_quotes/options/{0}.json').format(ticker.upper()).strip()
+    api_url = environ.get("API_URL", 'https://cdn.cboe.com/api/global/quotes/options/{0}.json').format(ticker.upper()).strip()
     logger.debug(f"API URL for {ticker}: {api_url}")
     ticker = ticker.lower() if ticker[0] != "_" else ticker[1:].lower()
     # The format of the data to download.


### PR DESCRIPTION
The user indicated that the source data is no longer delayed. I have removed the 15-minute delay logic across the application. This includes:
1. Modifying the data processing logic in `modules/calc.py` to use the actual data timestamp without offsetting it by 15 minutes.
2. Updating the UI in `modules/layout.py` to remove the "15-minute updates" and "(CBOE delayed data)" labels.
3. Updating the default API URL in `modules/ticker_dwn.py` to the non-delayed CBOE endpoint.
4. Updating `README.md` to reflect that the data is no longer 15-minute delayed.

All tests passed, and frontend changes were visually verified.

---
*PR created automatically by Jules for task [17028497646667422430](https://jules.google.com/task/17028497646667422430) started by @fxarb*